### PR TITLE
changes to gulp-parse-toc.js to build on windows

### DIFF
--- a/gulp-plugin/gulp-parse-toc.js
+++ b/gulp-plugin/gulp-parse-toc.js
@@ -19,10 +19,10 @@ module.exports = function (tocFilePath) {
     if (file.isStream()) return this.emit('error', 
       new PluginError('gulp-parse-toc',  'Streaming not supported'));
 
-    var filePath = file.path.split('/');
+    var filePath = file.path.split(path.sep);
     // Remove unwanted path frome the absolute source
     filePath = filePath.splice(filePath.indexOf('chapters'), filePath.length);
-    filePath = path.join.apply({}, filePath);
+    filePath = path.join.apply({}, filePath).replace(path.sep, "/");
     files[filePath] = file;
   }
 
@@ -43,7 +43,7 @@ module.exports = function (tocFilePath) {
       if (results === null) return;
       matchedPath = results[2];
       
-      constructedPath = path.join(tempPath.join('/'), matchedPath);
+      constructedPath = path.join(tempPath.join('/'), matchedPath).replace(path.sep, "/");
       if ( files[constructedPath] ) {
         resultFiles.push(files[constructedPath]);
       } else {


### PR DESCRIPTION
I wasn't able to build the output on windows 8.1
When loading the toc.md the path separators were windows-style, so the file path wasn't split correctly when using '/'. Next up when reading the .md files and linking to other files, the '/' was always used, but matched paths on disk were using the '\'

This now builds the pdf and the site at least. As I don't fully understand yet how files are pushed into the gulp-parse-toc.js plugin, I suppose this is not the best way to do it but I'm not sure how to fix it more elegantly.

changes
- toc file filePath split with path.sep instead of '/'
- replace path.sep with '/' for linked files
