### PR TITLE
Add deploy task in gulpfile.js (#39)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,9 +99,9 @@ gulp.task('generate:epub', ['concat'], function () {
 /*
  * Deploy the contents of the site folder to github pages (gh-pages)
 **/
-gulp.task('deploy', function (cb) {
+gulp.task('deploy', ['generate:site'], function (cb) {
   return gulp.src(DEST_DIR + '/site/**/*')
-    .pipe(deploy('git@github.com:rowoot/book-of-modern-frontend-tooling.git', 'origin'));
+    .pipe(deploy('git@github.com:tooling/book-of-modern-frontend-tooling.git', 'origin'));
 });
 
 /*

--- a/package.json
+++ b/package.json
@@ -22,20 +22,21 @@
   "homepage": "https://github.com/addyosmani/book-of-modern-frontend-tooling",
   "devDependencies": {
     "gulp-util": "~2.2.14",
-    "gulp": "~3.5.2",
+    "gulp": "~3.5.5",
     "gulp-markdown": "~0.1.2",
     "through2": "~0.4.1",
     "gulp-concat": "~2.1.7",
     "gulp-pandoc": "~0.2.0",
     "gulp-clean": "~0.2.4",
-    "gulp-markdown-pdf": "~0.1.1",
-    "gulp-ruby-sass": "~0.3.1",
+    "gulp-markdown-pdf": "~0.2.0",
+    "gulp-ruby-sass": "~0.4.0",
     "node-static": "~0.7.3",
-    "gulp-livereload": "~1.1.1",
+    "gulp-livereload": "~1.2.0",
     "rimraf": "~2.2.6",
-    "jade": "~1.1.5",
+    "jade": "~1.3.0",
     "gulp-layoutize": "~0.0.2",
-    "gulp-replace": "^0.2.0"
+    "gulp-replace": "^0.2.0",
+    "gulp-gh-pages": "~0.1.3"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
This PR addresses two things 
1. #39 by adding a `deploy` task to `gulpfile.js`
2. Update versions of dependencies in `package.json`

The gulp task `deploy` (using [gulp-gh-pages plugin](https://github.com/rowoot/gulp-gh-pages/blob/master/index.js)) does the following:
1. Clone remote repo
2. Checkout `gh-pages` branch (create if it doesn't exist)
3. Copy files specified in `gulp.src`
4. Add files (if no new changes are detected, it stops here)
5. Commit with message "Updates"
6. Push to remote

The task looks as below.

```
gulp.src([])
.pipe(deploy(gitRemoteUrl, remote) // plugin emits the files for further piping
```

Again, feedback appreciated.
