### PR TITLE
Fix typo in chapters/dependency-management/npm-browserify/getting-started.md (browserify 9.0.3)

### DIFF
--- a/chapters/dependency-management/npm-browserify/getting-started.md
+++ b/chapters/dependency-management/npm-browserify/getting-started.md
@@ -32,7 +32,7 @@ If you were to try to run this in a browser now it would fail, because there is 
 To generate a bundled JavaScript file, we need to pass Browserify the main file in our application. It will then recursively go through each file and its dependencies.
 
 ```bash
-$ browserify app.js --output bundle.js
+$ browserify app.js --outfile bundle.js
 ```
 
 This instructs Browserify to start parsing at `app.js` and then output to `bundle.js`. Now we can add `bundle.js` to our HTML file:


### PR DESCRIPTION
Maybe just `-o` would be good, too.