### PR TITLE
Fixes TOC links for gulp task chapters: fixes #83

### DIFF
--- a/chapters/toc.md
+++ b/chapters/toc.md
@@ -42,6 +42,7 @@
   * Gulp
     * [Introduction](build-systems/gulp/introduction.md)
     * [Getting Started](build-systems/gulp/getting-started.md)
-    * [Writing Tasks](build-systems/gulp/writing-tasks.md)
+    * [Writing Basic Tasks](build-systems/gulp/basic-tasks.md)
+    * [Writing Advanced Tasks](build-systems/gulp/advanced-tasks.md)
     * [References](build-systems/gulp/references.md)
 


### PR DESCRIPTION
Removes reference to the non-existent` writing-tasks.md` file and adds links for the basic and advanced chapters that were introduced in e0c15fa06.