### PR TITLE
Typo of *depedencies* Fixes issue91

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A free open-source book introducing you to the world of tooling for modern web a
   * Command-line
   * Node and npm
 * Build systems
-  * [Introduction](https://github.com/tooling/book-of-modern-frontend-tooling/issues/19) 
+  * [Introduction](https://github.com/tooling/book-of-modern-frontend-tooling/issues/19)
   * [Grunt](https://github.com/tooling/book-of-modern-frontend-tooling/issues/2)
   * [Brunch](https://github.com/tooling/book-of-modern-frontend-tooling/issues/5)
   * [Gulp](https://github.com/tooling/book-of-modern-frontend-tooling/issues/3)
@@ -28,7 +28,7 @@ A free open-source book introducing you to the world of tooling for modern web a
 
 This book is currently in progress. The idea is to capture enough useful content on each topic that a beginner could get started with a specific tool in a short space of time.
 
-We will aim to present all tools in a balanced light, providing the user with enough information to make up their minds on what makes sense for them to use. 
+We will aim to present all tools in a balanced light, providing the user with enough information to make up their minds on what makes sense for them to use.
 
 The book will be kept up to date by the authors and pull requests from the community will be happily accepted as with any OSS project.
 
@@ -38,7 +38,7 @@ We are currently looking for:
 
 * Authors interested in contributing new content on one of the topics above
 * Authors who have previously written detailed posts about one of the suggested topics that could be refreshed and integrated
-* Devs interested in helping us improve the current build setup 
+* Devs interested in helping us improve the current build setup
 
 New issues will be created for each corresponding section so commenting on the appropriate thread would be the best way to let us know you're interested.
 
@@ -48,7 +48,7 @@ Blog posts are an excellent way to spread knowledge, but they are typically ephe
 
 ## Generating the book
 
-### Depedencies
+### Dependencies
 
 At the moment, the following dependencies are required to export the book to EPUB file format.
 


### PR DESCRIPTION
Changed *depedencies* to *dependencies* at README.md

The other line changes are auto-removal of trailing whitespaces